### PR TITLE
add kubernetes-networks homework

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: homework
+  name: nginxconf
+data:
+  default.conf: |
+     server {
+       listen       8000;
+       server_name  localhost;
+       location / {
+         root /homework;
+         rewrite ^ /index.html break; 
+        }
+      }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  homework-network
+  namespace: homework
+  labels:
+    app: homework-network
+spec:
+  selector:
+    matchLabels:
+      app: homework-network
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: homework-network
+    spec:
+      containers:
+      - name: websrv
+        image: "nginx:latest"
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        ports:
+          - containerPort: 8000
+            name:  http
+        volumeMounts:
+          - name: homework
+            mountPath: /homework
+          - name: nginxconf
+            mountPath: /etc/nginx/conf.d/
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","rm -f /homework/index.html"]
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 3      
+      initContainers:
+      - name: install
+        image: busybox:latest
+        command:
+        - wget
+        - "-O"
+        - "/init/index.html"
+        - http://info.cern.ch
+        volumeMounts:
+        - name: homework
+          mountPath: "/init"
+      volumes:
+        - name: homework
+          emptyDir:
+            sizeLimit: 1Mi
+        - name: nginxconf
+          configMap:
+            name: nginxconf
+      restartPolicy: Always
+      nodeSelector:
+        homework: "true"
+      
+                  
+
+
+            
+
+        

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homework-network
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/index.html$ http://homework.otus/homepage permanent;
+spec:
+  rules:
+  - host: "homework.otus"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: homework-network
+            port:
+              number: 8000

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: homework
+  name: homework
+  resourceVersion: "76588"
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-network
+  namespace: homework
+spec:
+  selector:
+    app: homework-network
+  type: ClusterIP
+  ports:
+  - name: homework-network
+    protocol: TCP
+    port: 8000
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Изменил  readiness-пробу в манифесте deployment.yaml из
прошлого ДЗ на httpGet /index.html
-  создал манифест service.yaml, который описывает сервис
типа ClusterIP
- Установил в кластер ingress-контроллер nginx
- Создал ingress, который направляет все http запросы к хосту
homework.otus на ранее созданный сервис 
- Добавил rewrite-правила на ingress, так что бы по адресу http://homework.otus/index.html
форвардилось на http://homework.otus/homepage


## Как запустить проект:
 - minikube addons enable ingress
 - Добавить '127.0.0.1 homework.otus' в /etc/hosts
 - kubectl apply -f namespace.yaml
 - kubectl apply -f deployment.yaml
 - kubectl apply -f service.yaml
 - kubectl apply -f ingress.yaml

## Как проверить работоспособность:
 - minikube tunnel
 - открыть в браузере http://homework.otus/index.html

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
