### PR TITLE
add kubernetes-operator

### DIFF
--- a/kubernetes-operators/bash-mysql-operator/Dockerfile
+++ b/kubernetes-operators/bash-mysql-operator/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/flant/shell-operator:latest
+RUN apk add envsubst
+ADD hooks /hooks
+ADD templates /templates

--- a/kubernetes-operators/bash-mysql-operator/build.sh
+++ b/kubernetes-operators/bash-mysql-operator/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#build docker images
+eval $(minikube -p minikube docker-env) && \
+docker build . -t  evgsh555/bash-mysql-operator

--- a/kubernetes-operators/bash-mysql-operator/hooks/mysql-crd-hook.sh
+++ b/kubernetes-operators/bash-mysql-operator/hooks/mysql-crd-hook.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+function add_res {
+    export name=$1
+    export namespace=$2
+    export image=$3
+    export password=$4
+    export size="${5}Gi"
+    export dbname=$6
+    cat /templates/mysql-pv.yaml | envsubst > /tmp/_mysql-pv.yaml
+    cat /templates/mysql-deployment.yaml | envsubst  > /tmp/_mysql-deployment.yaml
+    kubectl apply -n $namespace  -f /tmp/_mysql-pv.yaml
+    kubectl apply -n $namespace  -f /tmp/_mysql-deployment.yaml
+    rm -f  /tmp/_mysql-*
+    true
+}
+
+function del_res {
+    export name=$1
+    export namespace=$2
+    kubectl -n $namespace delete deployment mysql-crd-$name 
+    kubectl -n $namespace delete service mysql-crd-$name
+    kubectl -n $namespace delete pvc mysql-crd-${name}-pvc
+    kubectl -n $namespace delete pv mysql-crd-${name}-persistent-storage
+    true
+}
+
+if [[ $1 == "--config" ]] ; then
+  cat <<EOF
+{
+  "configVersion":"v1",
+  "kubernetes":[{
+    "apiVersion": "otus.homework/v1",
+    "kind": "Mysqls",
+    "executeHookOnEvent":["Added","Deleted"]
+  }]
+}
+EOF
+else
+  type=$(jq -r '.[0].type' ${BINDING_CONTEXT_PATH})
+  if [[ $type == "Synchronization" ]] ; then
+    echo "Starting Synchronization "
+    for obj in $(jq '.[].objects' ${BINDING_CONTEXT_PATH}| jq -c '.[] | @base64')
+        do 
+        add_res $(echo $obj | base64 -d | jq -r '.object.metadata.name') \
+                $(echo $obj | base64 -d | jq -r '.object.metadata.namespace') \
+                $(echo $obj | base64 -d | jq -r '.object.spec.image') \
+                $(echo $obj | base64 -d | jq -r '.object.spec.password') \
+                $(echo $obj | base64 -d | jq -r '.object.spec.storage_size') \
+                $(echo $obj | base64 -d | jq -r '.object.spec.database') 
+     done   
+  elif [[ $type == "Event" ]] ; then
+  watchEvent=$(jq -r '.[0].watchEvent' ${BINDING_CONTEXT_PATH} )
+    name=$(jq -r '.[0].object.metadata.name' ${BINDING_CONTEXT_PATH})
+    namespace=$(jq -r '.[0].object.metadata.namespace' ${BINDING_CONTEXT_PATH})
+    if [[ $watchEvent == "Deleted" ]]; then  
+       echo "Removing resources $name in $namespace"
+       del_res $name $namespace
+    elif [[ $watchEvent == "Added" ]]; then  
+       echo "Creating resources $name in $namespace"
+       add_res $name $namespace $(jq -r '.[0].object.spec.image' ${BINDING_CONTEXT_PATH}) \
+                                $(jq -r '.[0].object.spec.password' ${BINDING_CONTEXT_PATH}) \
+                                $(jq -r '.[0].object.spec.storage_size' ${BINDING_CONTEXT_PATH}) \
+                                $(jq -r '.[0].object.spec.database' ${BINDING_CONTEXT_PATH})   
+    fi 
+  fi
+fi

--- a/kubernetes-operators/bash-mysql-operator/templates/mysql-deployment.yaml
+++ b/kubernetes-operators/bash-mysql-operator/templates/mysql-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-crd-${name}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: mysql-crd-${name}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-crd-${name}
+spec:
+  selector:
+    matchLabels:
+      app: mysql-crd-${name}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql-crd-${name}
+    spec:
+      containers:
+      - image: ${image}
+        name: mysql-crd-${name}
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: ${password}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-crd-${name}-persistent-storage
+          mountPath: /var/lib/mysql
+        lifecycle:
+          postStart:
+            exec:
+              command: 
+              - /bin/bash
+              - -c
+              - | 
+                until mysqladmin -uroot -p${password} create  ${dbname} &>/dev/null; do
+                  echo "createing db  ${dbname}"
+                  sleep 5;
+                  if mysql -N -${password} -e 'show databases' 2>/dev/null  | cat | grep  ${dbname}  &>/dev/null ; then
+                    echo "Existing ${dbname}"
+                    break;
+                  fi
+                done
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - mysqladmin  -p${password} ping
+          initialDelaySeconds: 5
+          periodSeconds: 5       
+        readinessProbe:
+          exec:
+            command: 
+            - /bin/bash
+            - -c
+            - mysql -N -p${password} -e "show databases" 2>/dev/null  | cat | grep  -q ${dbname}
+          initialDelaySeconds: 5
+          periodSeconds: 5       
+      volumes:
+      - name: mysql-crd-${name}-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-crd-${name}-pvc

--- a/kubernetes-operators/bash-mysql-operator/templates/mysql-pv.yaml
+++ b/kubernetes-operators/bash-mysql-operator/templates/mysql-pv.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-crd-${name}-persistent-storage
+  finalizers: []
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: ${size}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/pv-${name}"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-crd-${name}-pvc
+  finalizers: []
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${size}

--- a/kubernetes-operators/deployment.yaml
+++ b/kubernetes-operators/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  mysql-operator
+  namespace: default
+  labels:
+    app:  mysql-operator
+spec:
+  selector:
+    matchLabels:
+      app: mysql-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app:  mysql-operator
+    spec:
+      serviceAccountName: mysql-sa
+      containers:
+      - name:  mysql-operator
+        image:  roflmaoinmysoul/mysql-operator:1.0.0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+      restartPolicy: Always

--- a/kubernetes-operators/deployment2.yaml
+++ b/kubernetes-operators/deployment2.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  mysql-operator
+  namespace: default
+  labels:
+    app:  mysql-operator
+spec:
+  selector:
+    matchLabels:
+      app: mysql-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app:  mysql-operator
+    spec:
+      serviceAccountName: mysql-sa
+      containers:
+      - name:  mysql-operator
+        image:  evgsh555/bash-mysql-operator:latest
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+      restartPolicy: Always

--- a/kubernetes-operators/mysql.yaml
+++ b/kubernetes-operators/mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name:  mysql1
+  finalizers: []
+spec:
+  database: homework1
+  password: test_123
+  storage_size: "10"
+  image: mysql:5.6

--- a/kubernetes-operators/resourcedefinition.yaml
+++ b/kubernetes-operators/resourcedefinition.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+  namespace: homework
+  finalizers: []
+spec:
+  group: otus.homework
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                database:
+                  type: string
+                  pattern: ^[a-z0-9_-]{1,12}$
+                image:
+                  type: string
+                  pattern: ^.{1,24}$
+                password:
+                  type: string
+                  pattern: ^.{1,12}$
+                storage_size:
+                  type: string
+                  pattern: ^[0-9]{1,3}$
+              required:
+              - database
+              - image
+              - password
+              - storage_size
+  scope: Namespaced
+  names:
+    plural: mysqls
+    singular: mysql
+    kind: MySQL
+  

--- a/kubernetes-operators/role.yaml
+++ b/kubernetes-operators/role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mysql-role
+rules:
+- apiGroups: [""]
+  resources: ["services","persistentvolumes","persistentvolumeclaims","events"]
+  verbs: ["*"]
+- apiGroups: ["apps","extensions"]
+  resources: ["deployments","deployments/status"]
+  verbs: ["*"]
+- apiGroups: ["otus.homework"]
+  resources: ["mysqls"]
+  verbs: ["*"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["*"]

--- a/kubernetes-operators/rolebinding.yaml
+++ b/kubernetes-operators/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mysql-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mysql-role
+subjects:
+- kind: ServiceAccount
+  namespace: default
+  name: mysql-sa

--- a/kubernetes-operators/sa.yaml
+++ b/kubernetes-operators/sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-sa
+  namespace: default


### PR DESCRIPTION
# Выполнено ДЗ № 9

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Разработан CustomResourceDefinition по условиям в ДЗ
- Добавлены манифесты для создания sa,role,rolebinding с минимальными правами для работу оператора
- Добавлен  манифест deployment для установки оператора из примера roflmaoinmysoul/mysql-operator:1.0.0  см файл deployment.yaml
- Разработан собственный оператор установки mysql в кластер на основе shell-operator по  условиям из ДЗ,  см каталог  bash-mysql-operator и создан deployment для него, файл deployment2.yaml
-  Добавлен пример манифеста установки mysql в кластер на основе разработанного оператора cм файл mysql.yaml
 
## Как запустить проект:
```
#deploy role
kubectl apply -f  sa.yaml
kubectl apply -f  role.yaml
kubectl apply -f  rolebinding.yaml
#deploy crd
kubectl apply -f  resourcedefinition.yaml
#build project
cd bash-mysql-operator/ && ./build.sh && cd ..
#deploy operator
kubectl apply -f  deployment2.yaml
#deploy example mysql resource
kubectl apply -f  mysql.yaml
```


## Как проверить работоспособность:
 - Пробросим порт kubectl port-forward svc/mysql-crd-mysql1 3306
 - Подключимся к серверу с паролем из примера утилитой mysql
 
## PR checklist:
 - [x] Выставлен label с темой домашнего задания
